### PR TITLE
Added asset file size to library template.

### DIFF
--- a/templates/library.html
+++ b/templates/library.html
@@ -28,9 +28,10 @@
             <tbody>
               {{#files}}
               <tr class="library">
-                <td class="library-column"  data-lib-name="{{library.name}}" style="position: relative; padding: 8px;">
-                  <p class='library-url'>//cdnjs.cloudflare.com/ajax/libs/{{library.originalName}}/{{version}}/{{.}}</p>
+                <td class="library-column"  data-lib-name="{{library.name}}" style="position: relative;">
+                  <p class='library-url'>//cdnjs.cloudflare.com/ajax/libs/{{library.originalName}}/{{version}}/{{name}}</p>
                 </td>
+                <td style="position: relative;">{{size}} KiB</td>
               </tr>
               {{/files}}
             </tbody>


### PR DESCRIPTION
Display each asset's file size on the library page. This pull requires cdnjs/cdnjs#3264 to be merged first.
