### PR TITLE
use protocol-relative url to load disqus' library

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -116,7 +116,7 @@
     (function () {
     var s = document.createElement('script'); s.async = true;
     s.type = 'text/javascript';
-    s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+    s.src = '//' + disqus_shortname + '.disqus.com/count.js';
     (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
     </script>


### PR DESCRIPTION
I think we should use a protocol-relative here, or the browser will tell user that some elements in the page is insecure, becauseI'm not familiar with cdnjs' website, so I still send a pull request instead of commit into master branch.
