### PR TITLE
Remove the "exact" criterion from Algolia's ranking formula

### DIFF
--- a/reindex.js
+++ b/reindex.js
@@ -128,7 +128,8 @@ function initIndex(next) {
     attributesToIndex: ['unordered(name)', 'unordered(alternativeNames)', 'unordered(description)', 'unordered(keywords)', 'unordered(filename)'],
     customRanking: [ 'desc(github.stargazers_count)', 'asc(name)' ],
     attributesForFaceting: ['fileType', 'keywords'],
-    optionalWords: ['js', 'css'] // those words are optional (jquery.colorbox.js <=> jquery.colorbox)
+    optionalWords: ['js', 'css'], // those words are optional (jquery.colorbox.js <=> jquery.colorbox)
+    ranking: ['typo', 'words', 'proximity', 'attribute', 'custom'] // removed the "exact" criteria conflicting with the "keywords" array containing exact forms
   }, function(error, content) {
     next();
   });


### PR DESCRIPTION
This criterion is use to "boost" records matching exactly the query words but it makes libraries having "backbone" in their "keywords" attribute being ranked higher than the "backbone.js" library if query is "backbone". Not a big deal, I've just removed it here.