### PR TITLE
Avoid any XSS issue while displaying the package description in the search results

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -88,12 +88,17 @@
           '<li><i class="fa fa-code-fork"></i> ' + hit.github.forks + '</li>' +
         '</ul>';
       }
+
+      // extract & escape the description to prevent any XSS issue keeping the highlighting tags
+      var description = hit._highlightResult.description && hit._highlightResult.description.value;
+      description = $('<div />').text(description).html().replace(/&lt;(\/?)em&gt;/g, '<$1em>');
+
       var row = '<tr id="' + hit.objectID + '">' +
         '<td>' +
           '<p><a itemprop="name" href="/libraries/'+ hit.name + '">' +
             hit._highlightResult.name.value +
           '</a></p>' +
-          '<p class="text-muted">' + (hit._highlightResult.description && hit._highlightResult.description.value) + '</p>' +
+          '<p class="text-muted">' + description + '</p>' +
           '<ul class="list-inline">' +
             $.map(hit._highlightResult.keywords || [], function(e) { 
               var extraClass = (e.matchLevel !== 'none') ? 'highlight' : '';


### PR DESCRIPTION
This fixes https://github.com/cdnjs/cdnjs/issues/5462 escaping the description before displaying it. We keep the `<em></em>` tags to highlight the matching words.

![screen shot 2015-08-21 at 09 36 37](https://cloud.githubusercontent.com/assets/29529/9403620/eb1576ee-47e8-11e5-8342-e4ac0fc8f8c6.png)
