### PR TITLE
Add star and fork count on library page.

### DIFF
--- a/templates/library.html
+++ b/templates/library.html
@@ -7,6 +7,15 @@
         <div class="col-md-8">
 
     <h1 style="margin-top: 00px;">{{library.name}}</h1>
+    {{#library.repo}}
+    <br/>
+    <p>
+       <a aria-label="Star {{library.repo}} on GitHub" data-count-aria-label="# stargazers on GitHub" data-style="mega" data-count-api="/repos/{{library.repo}}#stargazers_count" data-count-href="/{{library.repo}}/stargazers" href="https://github.com/{{library.repo}}" class="github-button">Star</a>
+       &nbsp;
+       <a aria-label="Fork {{library.repo}} on GitHub" data-count-aria-label="# forks on GitHub" data-style="mega" data-count-api="/repos/{{library.repo}}#forks_count" data-count-href="/{{library.repo}}/network" data-icon="octicon-repo-forked" href="https://github.com/{{library.repo}}/fork" class="github-button">Fork</a>
+       <script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
+    </p>
+    {{/library.repo}}
     <p><a href="{{library.homepage}}">{{library.homepage}}</a>
       <span id="library-name" style="display: none;" hidden>{{library.name}}</span>
       <p><li class="label label-default label-highlight">{{library.autoupdateEnabled}}</li></p>

--- a/webServer.js
+++ b/webServer.js
@@ -160,6 +160,39 @@ function start() {
             return res.status(404).send('Library not found!');
         }
 
+        //Get the repository url
+        var urls = [];
+        // collect all repository urls
+        if (library.repositories && _.isArray(library.repositories)) {
+          for (var i = 0; i < library.repositories.length; ++i) {
+            urls.push(library.repositories[i].url);
+          }      
+        }
+        if (library.repository) {
+          if (_.isObject(library.repository)) {
+            urls.push(library.repository.url);
+          } else if (_.isString(library.repository)) {
+            urls.push(library.repository);
+          }   
+        }
+        // for each collected URL, try to find the associated github repo
+        var repos = _.compact(_.map(urls, function(url) {
+          if (!url || !_.isString(url)) {
+            return null;
+          }
+          var m = url.match(/.*github\.com\/([^\/]+)\/([^\/]+)(\/.*|\.git)?$/);
+          if (!m) {
+            return null;
+          }
+          return { user: m[1], repo: m[2].replace(/.git$/, '') };
+        }));
+  
+        library.repo = '';
+        if (repos.length > 0) {
+          var repo = repos[0]; // fetch only the first repository   
+          library.repo = repo.user + '/' + repo.repo;
+        }       
+       
         library.autoupdateEnabled = library.autoupdate ? library.autoupdate + ' autoupdate enabled' : '';
         var version = req.params.version || library.version;
 


### PR DESCRIPTION
- On each library's page, the PR use [github-buttons
  ](https://github.com/ntkme/github-buttons)for showing the **Star** and **Fork** of each git repository.
  - Modified `library.html`.
- To show the Star and Fork of git repopository, it required **`user`** and **`repository`** of git url.
  - Use method in **`reindex.js`** _(from line 78 - 105)_ for searching repository information.
  - Modified `webServer.js`
