### PR TITLE
Remove ZeroClipboard in favor of clipboard.js

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,6 +84,4 @@ $('.post').show();
 
 <script>hljs.initHighlightingOnLoad();</script>
 </body>
-
-  </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -44,7 +44,6 @@
        </div>
        </div>
 
-       
   </div>
 
     <div class="page">
@@ -55,7 +54,8 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.0.0/handlebars.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/js/bootstrap-dropdown.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/zeroclipboard/2.2.0/ZeroClipboard.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/js/bootstrap-tooltip.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.1/clipboard.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/algoliasearch/2.8.0/algoliasearch.min.js"></script>
   <script src="/js/main.js"></script>
 


### PR DESCRIPTION
Hello everyone.

This PR is related to issue #94.

The idea is to remove `ZeroClipboard` from the project, thus removing flash completely.

Tried to make the fewer changes possible to make the switch happen. Tough I think the code deserves some refactoring soon.

Besides that I added some tooltip feedback following the `bootstrap` pattern.

That's particularly useful if one is using Safari and need to use `Ctrl-C` or `Command-C` to copy.

### Notice about iOS

On iOS the copy button won't show, that's because it's not elegant to show a button and then discover that it actually won't work. Check [clipboard.js browser support](https://github.com/zenorocha/clipboard.js#browser-support).

The validation for iOS is currently `user-agent` based. I'm open to tips on how to improve that if needed.

Please review the PR and let me know what you think.