### PR TITLE
Adjust some code regarding the copy button

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -43,12 +43,10 @@
         var cont = $(ev.currentTarget);
         copyEl.show();
         copyEl.appendTo(cont);
-      })
-      .on( "mouseleave", function(ev) {
-        var cont = $(ev.currentTarget);
-        //copyEl.appendTo('body');
       });
-      if (clipboard) clipboard.destroy();
+      if (clipboard) {
+        clipboard.destroy();
+      }
       setupCopyButton();
     }
   }
@@ -102,6 +100,7 @@
         btContainer.tooltip('hide');
         btContainer.tooltip('destroy');
       }, 1000);
+      ga('send', 'event', 'library', 'copied', button.parents('.library-column').attr('data-lib-name'), 4);
     });
   }
 


### PR DESCRIPTION
Hello guys.

PR related to what was discussed in #97.

Made the changes following what @terinjokes pointed out.

Now it is logging the copy action even on the `clipboard error` event that occurs when people need to press `Ctrl-C` or `Command-C` to copy (when using Safari).

Please review.

Thank you.