### PR TITLE
drop watchers/open_issues_count in algolia index process

### DIFF
--- a/reindex.js
+++ b/reindex.js
@@ -114,9 +114,7 @@ function crawl(gnext) {
             user: repo.user,
             repo: repo.repo,
             stargazers_count: res.stargazers_count,
-            watchers_count: res.watchers_count,
             forks: res.forks,
-            open_issues_count: res.open_issues_count,
             subscribers_count: res.subscribers_count
           }
         } else {


### PR DESCRIPTION
@redox I think we didn't use watchers/open_issues_count and think we can remove them in the reindex process, what do you think? Thanks!