### PR TITLE
server push header added for http/2.0

### DIFF
--- a/webServer.js
+++ b/webServer.js
@@ -113,8 +113,44 @@ function start() {
         res.setHeader("Expires", new Date(Date.now() + 60 * 60 * hours * 1000).toUTCString());
     }
 
+    var serverPush = function(res, uri) {
+      var temp = uri.split('.'), ext = temp[temp.length-1], as = -1;
+      switch (ext) {
+        case 'js':
+          as='script';
+          break;
+        case 'css':
+          as='style';
+          break;
+        case 'png' :
+        case 'jpg' :
+        case 'jpeg':
+        case 'gif' :
+        case 'ico' :
+          as='image';
+          break;
+        case 'xml' :
+          as='';
+          break;
+      }
+      delete temp;
+      if (as != -1) {
+        res.append("Link", "<" + uri + ">; rel=preload; as=" + as );
+      }
+      delete temp;
+      delete ext;
+      delete as;
+    }
+
+    function pushAssets(res) {
+        serverPush(res, '/css/theme.css');
+        serverPush(res, '/css/main.css');
+        serverPush(res, '/js/main.js');
+    }
 
     app.get('/', function(req, res) {
+        pushAssets(res);
+        serverPush(res, '/img/algolia64x20.png');
         setCache(res, 2);
         res.send(generatePage({
             page: {


### PR DESCRIPTION
Though we are using http/1.1 in express/nodejs, we are using CDN that
supports http/2.0, this header will be sent to CDN server, so that CDN
server will push the files from cache to client.