### PR TITLE
fix copy button padding

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -3,6 +3,7 @@
 /*gitter button*/
 .gitter-open-chat-button{background-color:#dd4814;bottom:36px}
 .btn {font-size: inherit;    padding: 0px 0px;}
+.copy-button-group .copy-button { padding-left: 4px; }
 .dropdown-menu > li > a, .btn:hover, .btn:focus, .btn.focus {color:#dd4814}
 .dropdown-menu{ min-width: 0px; }
 ul.dropdown-menu > li { float: left; }


### PR DESCRIPTION
with all `.btn` elements' padding set to 0px, a bit of padding on specific elements will be needed. This fix covers the `copy` button's missing padding

### Before
![image](https://cloud.githubusercontent.com/assets/593791/16034023/74edff4c-31dd-11e6-8fdd-377b529b9b8e.png)

### After
![image](https://cloud.githubusercontent.com/assets/593791/16034044/8642be4a-31dd-11e6-994a-415d17c577c4.png)
