### PR TITLE
add popularity info on each lib's page

### DIFF
--- a/templates/library.html
+++ b/templates/library.html
@@ -7,6 +7,13 @@
         <div class="col-md-8">
 
     <h1 style="margin-top: 00px;" id="libraryName">{{library.name}}</h1>
+    {{#watch}}
+    <ul class="list-inline">
+      <li><i class="fa fa-eye"><strong> {{watch}}</strong></i></li>
+      <li><i class="fa fa-star"><strong> {{star}}</strong></i></li>
+      <li><i class="fa fa-code-fork"><strong> {{fork}}</strong></i></li>
+    </ul>
+    {{/watch}}
     <p><a href="{{library.homepage}}">{{library.homepage}}</a>
       <span id="library-name" style="display: none;" hidden>{{library.name}}</span>
       <p>


### PR DESCRIPTION
PR for #60 
It will show `watch`, `star`, `fork` information on each lib's page.
![cdnjs](https://raw.githubusercontent.com/pvnr0082t/Hello/master/Screenshot%20from%202017-01-08%2015-33-54.png)

For the library without git repository(no popularity info), it will show like this:
![no-repo](https://raw.githubusercontent.com/pvnr0082t/Hello/master/Screenshot%20from%202017-01-09%2020-15-50.png)