### PR TITLE
Show copy button when hovered in package-list/library page

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -74,10 +74,11 @@ function setFileURLs(new_provider) {
   function setupMouseEvents() {
     // Currently not showing the copy button for iOS, check clipboard.js support
     if (!(/iPhone|iPad/i.test(navigator.userAgent))) {
-      $('.library-column').hover(function(ev) {
+      $('.packages-table-container table tbody tr, .library-table-container table tbody tr').hover(function(ev) {
         var cont = $(ev.currentTarget);
+        var libraryColumn = cont.find('.library-column');
         copyEl.show();
-        copyEl.appendTo(cont);
+        copyEl.appendTo(libraryColumn);
       }, function(e){
         copyEl.hide();
       });

--- a/templates/library.html
+++ b/templates/library.html
@@ -51,7 +51,7 @@
       <div style="clear: both;"></div>
       <br />
       {{#selectedAssets}}
-      <div data-library-version="{{version}}" class="assets">
+      <div data-library-version="{{version}}" class="assets library-table-container">
           <table style="margin-top: 10px;" cellpadding="0" cellspacing="0" border="0" class="table table-striped" id="example">
             <tbody>
               {{#files}}


### PR DESCRIPTION
- [x] Show copy button on hover in library list page
- [x] Show copy button on hover in single library page
- [x] indent using spaces instead of tabs.

@PeterDaveHello 

PS: Messed up. Had to create a new PR.

#159 
