### PR TITLE
Fixes 164, Search bar now shows full list when no input

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -279,9 +279,9 @@ function setFileURLs(new_provider) {
 
     if (val === '') {
       $hits.html($allRows);
-      if(location.pathname === '/libraries'){
+      if (location.pathname === '/libraries') {
         $('.packages-table-container').show();
-      }else{
+      } else {
         $('.packages-table-container').hide();
       }
       animateTopReverse();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -279,7 +279,11 @@ function setFileURLs(new_provider) {
 
     if (val === '') {
       $hits.html($allRows);
-      $('.packages-table-container').hide();
+      if(location.pathname === '/libraries'){
+        $('.packages-table-container').show();
+      }else{
+        $('.packages-table-container').hide();
+      }
       animateTopReverse();
       appLoading.stop();
     } else if (lastQuery !== val) {


### PR DESCRIPTION
Fixes #164 

Library list was being cleared up when search value was made empty in the "/libraries" page.
However, that is the required behaviour in the "/" page. 

Now "/libraries" page shows up the original list when the search value is empty.


