### PR TITLE
Implement library not found page

### DIFF
--- a/templates/notfound.html
+++ b/templates/notfound.html
@@ -1,0 +1,11 @@
+<div class="container">
+  <div class="row">
+  <div class="col-lg-12">
+    <h3>Sorry, this page isn't available</h3>
+    <p>The link you followed may be broken, or the page may have been removed.</p>
+    <p>If you believe this was an error, report the bug on our <a target="_blank" href="https://github.com/cdnjs/new-website/issues">issues page</a>.</p>
+    <p>In the meantime, try browsing through our menu up top or refreshing.</p>
+  </div>
+  </div>
+</div>
+

--- a/webServer.js
+++ b/webServer.js
@@ -107,7 +107,8 @@ function start() {
     about: getTemplate('templates/about.html'),
     tutorials: getTemplate('templates/tutorials.html', true),
     tutorial: getTemplate('templates/tutorial.html', true),
-    api: getTemplate('templates/api.html', true)
+    api: getTemplate('templates/api.html', true),
+    notfound: getTemplate('templates/notfound.html', true)
   };
 
   var generatePage = function(options) {
@@ -488,6 +489,16 @@ function start() {
       page: {
         template: templates.api,
         title: 'API - ' + TITLE
+      }
+    }));
+  });
+
+  app.use(function(req, res) {
+    res.status(404).send(generatePage({
+      reqUrl: req.url,
+      title: '404: Page Not Found - ' + TITLE,
+      page: {
+        template: templates.notfound
       }
     }));
   });


### PR DESCRIPTION
close #78 

@PeterDaveHello As posted [here](https://github.com/cdnjs/new-website/issues/78#issuecomment-304511021), the content inside the template doesn't get displayed on encountering a 404 not found error.