### PR TITLE
[Website] Fix menu bar responsive issues

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -134,25 +134,24 @@ p#date{
 .container.home {
   margin-top: 200px;
 }
+
 .menu {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  margin-bottom: 10px;
-  margin-top: 20px;
+  font-size: 18px;
+  display: block;
+}
+
+.dropdown-menu li {
   width: 100%;
 }
-.menu li {
-  float: right;
-  margin-left: 15px;
-  font-size: 18px;
-}
+
 .logo {
-  float: left !important;
-  margin-left: 0 !important;
-}
-.logo a {
   font-weight: bold;
+}
+
+.btn-group .btn-space {
+  display: inline-block;
+  float: right;
+  margin-left: 1em !important;
 }
 
 .version-dropdown {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -44,76 +44,67 @@
     <div class="container {{wrapperClass}}">
       <div class="row">
         <div class="col-md-12">
-          <ul class="menu">
-            <li class="logo"><a href="/">cdnjs</a></li>
-            <li><a href="https://www.cloudflare.com/network-map" target="_blank">Network</a></li>
-            <li><a href="http://stats.pingdom.com/4jg86a2wqei0" target="_blank">Uptime</a></li>
-            <li class="">
-              <div class="btn-group">
-                <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                  git stats
-                <span class="caret"></span>
-                </a>
-                <ul class="dropdown-menu">
-                  <li class="dropdown-header">main repo</li>
-                  <li><a href="/git_stats/cdnjs/general.html" title="~201703" target="_blank">git_stats</a></li>
-                  <li><a href="/gitstats/cdnjs/" title="~201703" target="_blank">gitstats</a></li>
-                  <li class="dropdown-header">new-website</li>
-                  <li><a href="/git_stats/new-website/general.html" title="~201703" target="_blank">git_stats</a></li>
-                  <li><a href="/gitstats/new-website/" title="~201703" target="_blank">gitstats</a></li>
-                  <li class="dropdown-header">auto-updater</li>
-                  <li><a href="/git_stats/autoupdate/general.html" title="~201612" target="_blank">git_stats</a></li>
-                  <li><a href="/gitstats/autoupdate/" title="~201612" target="_blank">gitstats</a></li>
-                  <li class="dropdown-header">importer</li>
-                  <li><a href="/git_stats/cdnjs-importer/general.html" title="~201602" target="_blank">git_stats</a></li>
-                  <li><a href="/gitstats/cdnjs-importer/" title="~201602" target="_blank">gitstats</a></li>
-                  <li class="dropdown-header">buildScript</li>
-                  <li><a href="/git_stats/buildScript/general.html" title="~201612" target="_blank">git_stats</a></li>
-                  <li><a href="/gitstats/buildScript/" title="~201612" target="_blank">gitstats</a></li>
-                  <li class="dropdown-header">atom-extension</li>
-                  <li><a href="/git_stats/atom-extension/general.html" title="~201602" target="_blank">git_stats</a></li>
-                  <li><a href="/gitstats/atom-extension/" title="~201602" target="_blank">gitstats</a></li>
-                  <li class="dropdown-header">tutorials</li>
-                  <li><a href="/git_stats/tutorials/general.html" title="~201602" target="_blank">git_stats</a></li>
-                  <li><a href="/gitstats/tutorials/" title="~201602" target="_blank">gitstats</a></li>
-                </ul>
-              </div>
-            </li>
-            <li class="">
-              <div class="btn-group">
-                <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                  gource
-                <span class="caret"></span>
-                </a>
-                <ul class="dropdown-menu">
-                  <li><a href="https://youtu.be/ehwK-KM4uYQ" target="_blank">main repo</a></li>
-                  <li><a href="https://youtu.be/GLH7Ovzi5z8" target="_blank">new-website</a></li>
-                  <li><a href="https://youtu.be/Xe5s7fQQdwc" target="_blank">auto-updater</a></li>
-                  <li><a href="https://youtu.be/RUYALTcLkyU" target="_blank">importer</a></li>
-                  <li><a href="https://youtu.be/kc0DZWJAZm4" target="_blank">buildScript</a></li>
-                  <li><a href="https://youtu.be/OHQC1saKU_A" target="_blank">atom-extension</a></li>
-                  <li><a href="https://youtu.be/T6ZoTbRX1-A" target="_blank">tutorials</a></li>
-                </ul>
-              </div>
-            </li>
-            <li class="">
-              <div class="btn-group">
-                <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                  Support us!
-                <span class="caret"></span>
-                </a>
-                <ul class="dropdown-menu">
-                  <li><a href="https://www.bountysource.com/teams/cdnjs" target="_blank">via Bountysource</a></li>
-                  <li><a href="https://gratipay.com/cdnjs/" target="_blank">via Gratipay</a></li>
-                  <li><a href="https://tip4commit.com/github/cdnjs/cdnjs" target="_blank">via tip4commit</a></li>
-                  <li><a href="https://twitter.com/cdnjs" target="_blank">Contact us!</a></li>
-                </ul>
-              </div>
-            </li>
-            <li><a href="/libraries">Browse Libraries</a></li>
-            <li><a href="/api">API</a></li>
-            <li><a href="/about">About</a></li>
-            </ul>
+          <div class="menu btn-group">
+            <a class="btn btn-link logo" href="/">cdnjs</a>
+            <a class="btn btn-link btn-space" href="https://www.cloudflare.com/network-map" target="_blank">Network</a>
+            <a class="btn btn-link btn-space" href="http://stats.pingdom.com/4jg86a2wqei0" target="_blank">Uptime</a>
+            <div class="btn-group btn-space">
+              <a id="gitStatsGroupDrop" class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#">
+                git stats <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="gitStatsGroupDrop">
+                <li class="dropdown-header">main repo</li>
+                <li><a href="/git_stats/cdnjs/general.html" title="~201703" target="_blank">git_stats</a></li>
+                <li><a href="/gitstats/cdnjs/" title="~201703" target="_blank">gitstats</a></li>
+                <li class="dropdown-header">new-website</li>
+                <li><a href="/git_stats/new-website/general.html" title="~201703" target="_blank">git_stats</a></li>
+                <li><a href="/gitstats/new-website/" title="~201703" target="_blank">gitstats</a></li>
+                <li class="dropdown-header">auto-updater</li>
+                <li><a href="/git_stats/autoupdate/general.html" title="~201612" target="_blank">git_stats</a></li>
+                <li><a href="/gitstats/autoupdate/" title="~201612" target="_blank">gitstats</a></li>
+                <li class="dropdown-header">importer</li>
+                <li><a href="/git_stats/cdnjs-importer/general.html" title="~201602" target="_blank">git_stats</a></li>
+                <li><a href="/gitstats/cdnjs-importer/" title="~201602" target="_blank">gitstats</a></li>
+                <li class="dropdown-header">buildScript</li>
+                <li><a href="/git_stats/buildScript/general.html" title="~201612" target="_blank">git_stats</a></li>
+                <li><a href="/gitstats/buildScript/" title="~201612" target="_blank">gitstats</a></li>
+                <li class="dropdown-header">atom-extension</li>
+                <li><a href="/git_stats/atom-extension/general.html" title="~201602" target="_blank">git_stats</a></li>
+                <li><a href="/gitstats/atom-extension/" title="~201602" target="_blank">gitstats</a></li>
+                <li class="dropdown-header">tutorials</li>
+                <li><a href="/git_stats/tutorials/general.html" title="~201602" target="_blank">git_stats</a></li>
+                <li><a href="/gitstats/tutorials/" title="~201602" target="_blank">gitstats</a></li>
+              </ul>
+            </div>
+            <div class="btn-group btn-space">
+              <a id="gourceGroupDrop" class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#">
+                gource <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="gourceGroupDrop">
+                <li><a href="https://youtu.be/ehwK-KM4uYQ" target="_blank">main repo</a></li>
+                <li><a href="https://youtu.be/GLH7Ovzi5z8" target="_blank">new-website</a></li>
+                <li><a href="https://youtu.be/Xe5s7fQQdwc" target="_blank">auto-updater</a></li>
+                <li><a href="https://youtu.be/RUYALTcLkyU" target="_blank">importer</a></li>
+                <li><a href="https://youtu.be/kc0DZWJAZm4" target="_blank">buildScript</a></li>
+                <li><a href="https://youtu.be/OHQC1saKU_A" target="_blank">atom-extension</a></li>
+                <li><a href="https://youtu.be/T6ZoTbRX1-A" target="_blank">tutorials</a></li>
+              </ul>
+            </div>
+            <div class="btn-group btn-space">
+              <a id="supportGroupDrop" class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#">
+                Support us! <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="supportGroupDrop">
+                <li><a href="https://www.bountysource.com/teams/cdnjs" target="_blank">via Bountysource</a></li>
+                <li><a href="https://gratipay.com/cdnjs/" target="_blank">via Gratipay</a></li>
+                <li><a href="https://tip4commit.com/github/cdnjs/cdnjs" target="_blank">via tip4commit</a></li>
+                <li><a href="https://twitter.com/cdnjs" target="_blank">Contact us!</a></li>
+              </ul>
+            </div>
+            <a class="btn btn-link btn-space" href="/libraries">Browse Libraries</a>
+            <a class="btn btn-link btn-space" href="/api">API</a>
+            <a class="btn btn-link btn-space" href="/about">About</a>
+          </div>
        </div>
        </div>
 


### PR DESCRIPTION
Hi all,

I made some changes to the menu bar. Below are a couple of things I found a tad distracting:

1. The dropdown buttons (namely, "support," "gource" and "git status") have a slightly wider `margin-top` than the other links.

<img width="995" alt="screen shot 2017-06-19 at 8 30 31 pm" src="https://user-images.githubusercontent.com/14964777/27285306-e213b178-552e-11e7-99b1-8c976170f95c.png">

Here's my current version:

<img width="995" alt="screen shot 2017-06-19 at 8 37 08 pm" src="https://user-images.githubusercontent.com/14964777/27285447-5bbeaa50-552f-11e7-8648-3c704b253e99.png">

2. The dropdown buttons use Bootstrap's default `btn` class, which has a weird shadow on top that looks a bit out of place.

<img width="990" alt="screen shot 2017-06-19 at 8 41 21 pm" src="https://user-images.githubusercontent.com/14964777/27285672-001cd978-5530-11e7-82ac-ef8f042eff4f.png">

I changed them to the `btn-link` class, so as to accord with other link buttons.

<img width="991" alt="screen shot 2017-06-19 at 8 44 39 pm" src="https://user-images.githubusercontent.com/14964777/27285717-29e99db8-5530-11e7-8b1e-6d92d751d35e.png">

3. `background-color` of dropdown items does not extend to full width of its parent `div`; I fixed this (see above).

4. Original dropdown menus align with the left border of their toggle elements. I changed them to align with the right border, because the menu items themselves are floating right (see above); I am willing to talk about this though—removing `.dropdown-menu-right` in HTML will revert to the original behavior.

5. The positions of current menu items go wild when resized:

<img width="397" alt="screen shot 2017-06-19 at 8 54 37 pm" src="https://user-images.githubusercontent.com/14964777/27286120-9dba0bc8-5531-11e7-83f5-2e0694f7dcf2.png">

Here's my version:

<img width="397" alt="screen shot 2017-06-19 at 8 54 58 pm" src="https://user-images.githubusercontent.com/14964777/27286142-b175c1c0-5531-11e7-8aae-9cae855f58d7.png">

6. `.menu { font-size: 18px; }` does not apply to dropdown items, and the latter now look a bit smaller. This is partly because the super long "git stats" menu.. we can add a rule easily if someone prefers the original font size.

Thanks and happy to discuss any of these changes!