### PR TITLE
[Website] clean up highlight.js (fixed #72)

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -20,7 +20,6 @@
     <meta name="keywords" content="{{keywords}}" />
     <link rel="preconnect" href="//cdnjs.cloudflare.com" pr="1.0" />
     <link rel="preconnect" href="//www.algolia.com" pr="0.85" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/default.min.css" integrity="sha256-Zd1icfZ72UBmsId/mUcagrmN7IN5Qkrvh75ICHIQVTk=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/themes/orange/pace-theme-minimal.min.css" integrity="sha256-kb8pRNu1sIwQEWAO/Mqt1S5PZ5xiLd4nBMoSsqdxKPs=" crossorigin="anonymous" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js" integrity="sha256-EPrkNjGEmCWyazb3A/Epj+W7Qm2pB9vnfXw+X6LImPM=" crossorigin="anonymous" async></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/united/bootstrap.min.css" integrity="sha256-mKuwI+x5TH/8YJ3N3ZHLGK0+IMRL4bZ1Me+2ylaxrwY=" crossorigin="anonymous" />

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -151,7 +151,6 @@ $('.post > pre > code').wrapInner('<div class="container"><div class="row"><div 
 $('.post code').addClass('hljs');
 $('.post').show();
     </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/highlight.min.js" integrity="sha256-fkOAs5tViC8MpG+5VCOqdlSpLL8htz4mdL2VZlWGoMA=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollup/2.4.1/jquery.scrollUp.min.js" integrity="sha256-t2YrqZoTLq/Qt8zIw0BMiuRC2X5+a3O7PODU8RwoyYw=" crossorigin="anonymous"></script>
 
 <script defer>hljs.initHighlightingOnLoad();</script>

--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -26,8 +26,8 @@ h1,h2,h3,h4,h5 {
   margin: 20px 0 20px 0;
 }
 .divider {
-  background: #dd4814;
-  color: #ebebeb;
+  background: #dd4814; 
+  color: #ebebeb; 
   padding: 5px;
   margin: 40px 0;
 }

--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -1,5 +1,4 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" integrity="sha256-/BfiIkHlHoVihZdc6TFuj7MmJ0TWcWsMXkeDFwhi0zw=" crossorigin="anonymous"></script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/monokai-sublime.min.css" integrity="sha256-k5mFes0QrsMTUCIg7sRlizkZIhMeL4fTABLlkjQmR0s=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/monokai_sublime.min.css" integrity="sha256-p7iXCLgo7yYL7S/4wvsCDAFSqcQhow/2LeoLGD09kys="crossorigin="anonymous">
 <link href='https://fonts.googleapis.com/css?family=Roboto:400italic,700italic,700,400' rel='stylesheet' type='text/css'>
 <style>
 .post {
@@ -156,3 +155,5 @@ p > code.hljs {
     </div>
   </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/highlight.min.js" integrity="sha256-fkOAs5tViC8MpG+5VCOqdlSpLL8htz4mdL2VZlWGoMA=" crossorigin="anonymous"></script>
+<script defer>hljs.initHighlightingOnLoad();</script>

--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -1,4 +1,5 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/monokai_sublime.min.css" integrity="sha256-p7iXCLgo7yYL7S/4wvsCDAFSqcQhow/2LeoLGD09kys="crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" integrity="sha256-/BfiIkHlHoVihZdc6TFuj7MmJ0TWcWsMXkeDFwhi0zw=" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/monokai-sublime.min.css" integrity="sha256-k5mFes0QrsMTUCIg7sRlizkZIhMeL4fTABLlkjQmR0s=" crossorigin="anonymous" />
 <link href='https://fonts.googleapis.com/css?family=Roboto:400italic,700italic,700,400' rel='stylesheet' type='text/css'>
 <style>
 .post {
@@ -25,8 +26,8 @@ h1,h2,h3,h4,h5 {
   margin: 20px 0 20px 0;
 }
 .divider {
-  background: #dd4814; 
-  color: #ebebeb; 
+  background: #dd4814;
+  color: #ebebeb;
   padding: 5px;
   margin: 40px 0;
 }


### PR DESCRIPTION
This change makes sure highlight.js will only be requested when visiting the tutorial page (closed issue #72).

Also updated highlight.js and styles/monokai-sublime.min.css to their [latest version](https://cdnjs.com/libraries/highlight.js) (v9.12.0).