### PR TITLE
Allow "hitsPerPage" and "page" query parameters

### DIFF
--- a/apiServer.js
+++ b/apiServer.js
@@ -83,11 +83,15 @@ app.get('/libraries', function(req, res) {
 
   res.setHeader("Expires", new Date(Date.now() + 360 * 60 * 1000).toUTCString());
   var fields = (req.query.fields && req.query.fields.split(',')) || [];
+  
   if (req.query.search) {
+    
     var searchParams = {
       typoTolerance: 'min', // only keep the minimum typos
-      hitsPerPage: 1000 // maximum
+      page: req.query.page || 0, // default
+      hitsPerPage: req.query.hitsPerPage || 1000 // maximum
     };
+
     algoliaIndex.search(req.query.search, searchParams, function(error, content) {
       if (error) {
         res.status(500).send(error.message);
@@ -120,6 +124,7 @@ app.get('/libraries', function(req, res) {
     }
   }
 });
+
 app.get('/libraries/:library', function(req, res) {
   var results;
   var fields = (req.query.fields && req.query.fields.split(',')) || false;

--- a/templates/api.html
+++ b/templates/api.html
@@ -19,7 +19,7 @@
         </h3>
         <div class="api">
           <p>
-            You can query cdnjs via our API as belows
+            You can query cdnjs via our API as below
             <br><br>
             Without any query parameters it will return the name and main file URL of every library on cdnjs:<br><br>
             <code>https://api.cdnjs.com/libraries</code>

--- a/templates/api.html
+++ b/templates/api.html
@@ -19,7 +19,7 @@
         </h3>
         <div class="api">
           <p>
-            You can query cdnjs via our API as below
+            You can query cdnjs via our API as belows
             <br><br>
             Without any query parameters it will return the name and main file URL of every library on cdnjs:<br><br>
             <code>https://api.cdnjs.com/libraries</code>
@@ -39,6 +39,14 @@
     <a href="https://github.com/cdnjs/cdnjs/blob/master/ajax/libs/jquery/package.json">
       CDNJS
     </a>(except auto-update config, we'll only return the auto-update type (currently <code>npm or git</code>)
+    <br><br>
+    The API will return the maximum results by default (1000), but you can limit these the "hitsPerPage" query
+    <br><br>
+    <code>https://api.cdnjs.com/libraries?search=[query]&hitsPerPage=10</code>
+    <br><br>
+    If you are using the "hitsPerPage" query, you can also use "page" to paginate (defaulting at 0)
+    <br><br>
+    <code>https://api.cdnjs.com/libraries?search=[query]&hitsPerPage=10&page=2</code>
     <br><br>
     API will return minified result by default, if you wanna have a human readable result, try
     <code>output=human</code>


### PR DESCRIPTION
This PR allows the apiServer to pass through `hitsPerPage` and `page` query params, as per the [Algolia api](https://www.algolia.com/doc/guides/searching/pagination/)

**Includes:**
- Small changes to `apiServer.js` to allow the passing of the params
- Changes to the documentation page, showing how to use the params