### PR TITLE
[Website] Display library assets only important files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "express": "^4.16.4",
     "git-url-parse": "^11.1.2",
     "github": "^13.1.0",
+    "glob-to-regexp": "^0.3.0",
     "gravatar": "^1.8.0",
     "highlight.js": "^9.14.2",
     "lodash": "^4.17.11",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -176,20 +176,21 @@
   function setupMouseEvents() {
     // Currently not showing the copy button for iOS, check clipboard.js support
     if (!(/iPhone|iPad/i.test(navigator.userAgent))) {
-      $('.packages-table-container table tbody tr, .library-table-container table tbody tr').hover(function (ev) {
-        // If we're on a search page, update the buttons for the right lib
-        if ($(".packages-table-container")[0]) {
-          copyEl.children('ul').remove();
-          copyEl.append(generateCopyDropdown(this.dataset.sri));
-        }
+      $('.packages-table-container table tbody tr, .library-table-container table tbody tr.library')
+        .hover(function (ev) {
+          // If we're on a search page, update the buttons for the right lib
+          if ($(".packages-table-container")[0]) {
+            copyEl.children('ul').remove();
+            copyEl.append(generateCopyDropdown(this.dataset.sri));
+          }
 
-        // Show the button
-        copyEl.appendTo($(ev.currentTarget).find('.library-column'));
-        copyEl.show();
-      }, function () {
-        // Hide the button when hover ends
-        copyEl.hide();
-      });
+          // Show the button
+          copyEl.appendTo($(ev.currentTarget).find('.library-column'));
+          copyEl.show();
+        }, function () {
+          // Hide the button when hover ends
+          copyEl.hide();
+        });
 
       // Setup the clipboard handler
       if (clipboard) clipboard.destroy();
@@ -435,6 +436,30 @@
   }
 
   /****
+   * Hidden Library Asset Scripting
+   ****/
+
+  function setupHiddenAssets() {
+    // If the user wants to view all the files on a library page, let them
+    $('a#show-hidden').click(function () {
+      $('tr.library.hiddenFile').each(function () {
+        $(this).show()
+      });
+      $('a#show-hidden').hide();
+      $('a#hide-hidden').show();
+    });
+
+    // Also let them reverse that decision
+    $('a#hide-hidden').click(function () {
+      $('tr.library.hiddenFile').each(function () {
+        $(this).hide()
+      });
+      $('a#hide-hidden').hide();
+      $('a#show-hidden').show();
+    });
+  }
+
+  /****
    * Main Scripting
    ****/
 
@@ -453,6 +478,9 @@
 
   // Do the initial search setup
   setupInitialSearch();
+
+  // Setup the logic for hidden library assets
+  setupHiddenAssets();
 
   // If the window hash changes, search again and update the CDN provider
   $(window).on('hashchange', function () {

--- a/templates/library.html
+++ b/templates/library.html
@@ -100,8 +100,21 @@
           <table style="margin-top: 10px;" cellpadding="0" cellspacing="0" border="0" class="table table-striped"
                  id="example">
             <tbody>
+            {{#hasHidden}}
+            <tr id="control-hidden">
+              <td colspan="2">
+                <a id="show-hidden" style="cursor: pointer;">
+                  Some files are hidden, click to show all files
+                </a>
+                <a id="hide-hidden" style="cursor: pointer; display: none;">
+                  All files are shown, click to hide non-essential files
+                </a>
+              </td>
+            </tr>
+            {{/hasHidden}}
             {{#files}}
-            <tr class="library {{fileType}}-type {{defaultFile}}">
+            <tr class="library {{fileType}}-type {{defaultFile}} {{#isHidden}}hiddenFile{{/isHidden}}"
+                style="/*{{#isHidden}}*/display: none;/*{{/isHidden}}*/">
               <td class="library-column" data-lib-name="{{library.name}}" style="position: relative;">
                 <p class="library-url">{{library.originalName}}/{{version}}/{{name}}</p>
               </td>


### PR DESCRIPTION
Refer to #54, the library asset only display *.min.js, *.min.css, and
`filename` field in package.json.

Fixes #54, cc @PeterDaveHello.