### PR TITLE
Add Swag Link

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -78,6 +78,7 @@
                 Support us! <span class="caret"></span>
               </a>
               <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="supportGroupDrop">
+                <li><a href="https://teespring.com/stores/cdnjs-swag" target="_blank">with cdnjs Swag</a></li>
                 <li><a href="https://www.bountysource.com/teams/cdnjs" target="_blank">via Bountysource</a></li>
                 <li><a href="https://liberapay.com/cdnjs/" target="_blank">via Liberapay</a></li>
                 <li><a href="https://tip4commit.com/github/cdnjs/cdnjs" target="_blank">via tip4commit</a></li>


### PR DESCRIPTION
Add the new teespring cdnjs swag link to the support us dropdown in the navbar.

Do not merge yet please - still working on more swag.