### PR TITLE
[Website] Update community links

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -88,7 +88,6 @@
             <a class="btn btn-link btn-space" href="/api">API</a>
             <a class="btn btn-link btn-space" href="/about">About</a>
             <a class="btn btn-link btn-space" href="https://discord.gg/38ZpCFP" target="_blank">Discord</a>
-            <a class="btn btn-link btn-space" href="https://community.cdnjs.com/" target="_blank">Community</a>
           </div>
         </div>
       </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -101,6 +101,10 @@
       <div class="container">
         <p class="text-muted">
           Donate CDNJS $5 on <a href="https://www.bountysource.com/teams/cdnjs" target="_blank">Bountysource</a> or become a contributor on <a href="https://github.com/cdnjs/cdnjs" target="_blank"><i class="fa fa-github"></i> GitHub</a> to make the project better and better!
+          <span class="pull-right">
+            <a href="https://twitter.com/cdnjs" target="_blank"><i class="fa fa-twitter-square"></i> Twitter</a>
+            &nbsp; <a href="https://discord.gg/38ZpCFP" target="_blank"><i class="fa fa-comments"></i> Discord</a>
+          </span>
         </p>
       </div>
     </footer>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -87,7 +87,7 @@
             <a class="btn btn-link btn-space" href="/libraries">Browse Libraries</a>
             <a class="btn btn-link btn-space" href="/api">API</a>
             <a class="btn btn-link btn-space" href="/about">About</a>
-            <a class="btn btn-link btn-space" href="https://discord.gg/38ZpCFP" target="_blank">Discord</a>
+            <a class="btn btn-link btn-space" href="https://discord.gg/38ZpCFP" target="_blank">Community Discord</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changes:
 * Community site is currently broken and I've had no reply in some time regarding this - Looks bad to have our community site being linked and also broken
 * Rename the Discord link to Community Discord so the community has an obvious place to go still
 * Add twitter + discord links to footer (twitter isn't linked anywhere else on site)

Notes:
 * Discord icon in footer can be replaced with actual discord icon once https://github.com/cdnjs/new-website/issues/260 / https://github.com/cdnjs/cdnjs/pull/12517 are resolved
 * Community forums link can be re-added once the issues with it are resolved if we decide that is worth doing