### PR TITLE
[Website] Highlight the default file in the library view

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -209,6 +209,36 @@ tbody {
   content: "/\00a0";
 }
 
+tr.defaultFile {
+  background: #fff5f2;
+  border-left: 4px solid #e95420;
+}
+
+tr.defaultFile td:first-child {
+  position: relative;
+}
+
+tr.defaultFile td:first-child::before {
+  background: rgba(0, 0, 0, .7);
+  border-radius: 5px;
+  color: #fff;
+  content: "This file has been marked as the default file for this library";
+  font-size: 12px;
+  left: .5em;
+  min-width: 300px;
+  opacity: 0;
+  padding: .25em .5em;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
+  top: -1em;
+  transition: opacity .2s;
+}
+
+tr.defaultFile:hover td:first-child::before {
+  opacity: 1;
+}
+
 @font-face {
   font-family: "GothamSSm";
   font-style: normal;

--- a/templates/library.html
+++ b/templates/library.html
@@ -101,7 +101,7 @@
                  id="example">
             <tbody>
             {{#files}}
-            <tr class="library {{fileType}}-type">
+            <tr class="library {{fileType}}-type {{defaultFile}}">
               <td class="library-column" data-lib-name="{{library.name}}" style="position: relative;">
                 <p class="library-url">{{library.originalName}}/{{version}}/{{name}}</p>
               </td>

--- a/webServer.js
+++ b/webServer.js
@@ -334,7 +334,11 @@ function start() {
         assets.files.map(function (fileName) {
           var fileExtension = path.extname(fileName);
           var fileType = fileExtension.substring(1) || 'unknown';
-          fileArray.push({ name: fileName, fileType: fileType });
+          fileArray.push({
+            name: fileName,
+            fileType: fileType,
+            defaultFile: fileName === library.filename ? 'defaultFile' : ''
+          });
         });
 
         assets.files = fileArray;


### PR DESCRIPTION
As requested by a user, to make it more clear which file is suggested to be used normally.
Highlight the provided filename from the package.json in the full library file view.

![image](https://user-images.githubusercontent.com/12371363/50962736-d8802b00-14c2-11e9-8047-f078ec5e8cc7.png)

Fixes #319