### PR TITLE
[Website] Fix GitHub banner & homepage responsiveness

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -3,8 +3,9 @@
 #fork-on-github a {
   background: #e95420;
   color: #fff;
+  display: block;
   font-family: arial, sans-serif;
-  font-size: 1rem;
+  font-size: 1.3rem;
   font-weight: bold;
   line-height: 2rem;
   padding: 5px 40px;
@@ -19,45 +20,29 @@
   color: #fff;
 }
 
-#fork-on-github a::before,
-#fork-on-github a::after {
-  background: #fff;
-  content: "";
-  display: block;
-  height: 1px;
-  left: 0;
-  position: absolute;
-  top: 1px;
-  width: 100%;
-}
-
-#fork-on-github a::after {
-  bottom: 1px;
-  top: auto;
-}
-@media screen and (min-width:1333px) {
+@media screen and (min-width: 1280px) {
 
   #fork-on-github {
     display: block;
     height: 200px;
     left: 0;
     overflow: hidden;
+    pointer-events: none;
     position: absolute;
     top: 0;
+    -webkit-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    -moz-transform: rotate(-45deg);
+    -o-transform: rotate(-45deg);
+    transform: rotate(-45deg);
     width: 200px;
-    z-index: 0;
+    z-index: 99;
   }
 
   #fork-on-github a {
-    box-shadow: 4px 4px 10px rgba(0, 0, 0, .8);
-    left: -45px;
-    position: absolute;
-    top: 30px;
-    -webkit-transform: rotate(315deg);
-    -ms-transform: rotate(315deg);
-    -moz-transform: rotate(315deg);
-    -o-transform: rotate(315deg);
-    transform: rotate(315deg);
+    display: inline-block;
+    margin: 10px 0;
+    pointer-events: auto;
     width: 200px;
   }
 }

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -12,7 +12,7 @@ html {
 }
 
 body {
-  margin-bottom: 25px;
+  margin-bottom: 50px;
   overflow-y: scroll;
 }
 

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -144,7 +144,21 @@ p#date{
 }
 
 .container.home {
-  margin-top: 200px;
+  margin-top: 0;
+}
+
+@media screen and (min-width: 330px) {
+
+  .container.home {
+    margin-top: 10vh;
+  }
+}
+
+@media screen and (min-width: 600px) {
+
+  .container.home {
+    margin-top: 25vh;
+  }
 }
 
 .menu {

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -172,7 +172,7 @@ p#date{
 .menu {
   display: block;
   font-size: 18px;
-  margin-top: 5px;
+  margin-top: 10px;
 }
 
 .dropdown-menu li {

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -150,6 +150,7 @@ p#date{
 .menu {
   display: block;
   font-size: 18px;
+  margin-top: 5px;
 }
 
 .dropdown-menu li {

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -4,11 +4,17 @@ html {
 }
 
 .footer {
-  background-color: #f5f5f5;
+  background-color: #ebebeb; /* same as logo */
+  border-top: 2px solid #dd4814;
   bottom: 0;
-  padding-top: 7px;
+  color: #6b6b6b;
+  padding: 10px 0;
   position: absolute;
   width: 100%;
+}
+
+.footer p {
+  margin: 0;
 }
 
 body {

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -140,6 +140,8 @@ p#date{
 }
 
 #search-box {
+  font-size: 16px;
+  height: 46px;
   margin: 0 0 15px 0;
 }
 

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -111,6 +111,10 @@ p#date{
   color: #ffdead;
 }
 
+tbody {
+  border: 1px solid #ddd;
+}
+
 .label-highlight a {
   color: white !important;
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -320,11 +320,13 @@
   }
 
   function animateTop() {
-    $('.container.home').animate({ marginTop: '0px' }, 200);
+    $('.container.home').animate({ marginTop: '0vh' }, 200);
   }
 
+  var normalMarginTop = $('.container.home').css("marginTop");
+
   function animateTopReverse() {
-    $('.container.home').animate({ marginTop: '200px' }, 200);
+    $('.container.home').animate({ marginTop: normalMarginTop }, 200);
   }
 
   var clearHash = _.once(function () {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -86,7 +86,7 @@
 
 <footer class="footer">
   <div class="container">
-    <p class="text-muted">
+    <p>
       Donate $5 to cdnjs via <a href="https://www.bountysource.com/teams/cdnjs" target="_blank">Bountysource</a>,
       <a href="https://opencollective.com/cdnjs" target="_blank">Open Collective</a> or
       <a href="https://www.patreon.com/cdnjs" target="_blank">Patreon</a>, or contribute on

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -71,10 +71,10 @@
           </ul>
         </div>
 
-        <a class="btn btn-link btn-space" href="/libraries">Browse Libraries</a>
         <a class="btn btn-link btn-space" href="/api">API</a>
         <a class="btn btn-link btn-space" href="/about">About</a>
         <a class="btn btn-link btn-space" href="https://cdnjs.discourse.group/" target="_blank">Community</a>
+        <a class="btn btn-link btn-space" href="/libraries">Browse Libraries</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Resolves #258 be correcting the rotation direction and updating the general styling to make it work better on tablets and mobile.
Resolves #18 by making the homepage margin-top responsive on all devices based on viewport height, giving the navigation a margin-top (and re-ordering to prioritise browsing libraries), making the search box larger for easier access on mobile and making the footer margin larger as well as the padding and making the text easier to read.