### PR TITLE
[Website] Add status page to nav w/ indicator dot & add statuspage pop-up

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -205,3 +205,28 @@ tr {
 .container {
     width: 87%;
 }
+
+/* statuspage indicator */
+.status-color-dot {
+  border-radius: 50%;
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 5px;
+}
+
+.status-color-dot.critical {
+  background-color: #e74c3c;
+}
+
+.status-color-dot.major {
+  background-color: #e67e22;
+}
+
+.status-color-dot.minor {
+  background-color: #f1c40f;
+}
+
+.status-color-dot.none {
+  background-color: #2ecc71;
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -43,8 +43,19 @@
         <div class="col-md-12">
           <div class="menu btn-group">
             <a class="btn btn-link logo" href="/">cdnjs</a>
-            <a class="btn btn-link btn-space" href="https://www.cloudflare.com/network-map" target="_blank">Network</a>
-            <a class="btn btn-link btn-space" href="http://stats.pingdom.com/4jg86a2wqei0" target="_blank">Uptime</a>
+            <div class="btn-group btn-space">
+              <a id="networkStatusGroupDrop" class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#">
+                Network &amp; Status<span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="networkStatusGroupDrop">
+                <li class="dropdown-header">Cloudflare Network</li>
+                <li><a href="https://www.cloudflare.com/network-map" target="_blank">Network Map</a></li>
+                <li class="dropdown-header">cdnjs.com &amp; CDN service</li>
+                <li><a href="http://stats.pingdom.com/4jg86a2wqei0" target="_blank">CDN Uptime</a></li>
+                <li><a href="https://status.cdnjs.com" target="_blank">Status Page</a></li>
+                <li><a href="https://twitter.com/cdnjsStatus" target="_blank">cdnjsStatus on Twitter</a></li>
+              </ul>
+            </div>
             <div class="btn-group btn-space">
               <a id="gitStatsGroupDrop" class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#">
                 git stats <span class="caret"></span>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -52,7 +52,11 @@
                 <li><a href="https://www.cloudflare.com/network-map" target="_blank">Network Map</a></li>
                 <li class="dropdown-header">cdnjs.com &amp; CDN service</li>
                 <li><a href="http://stats.pingdom.com/4jg86a2wqei0" target="_blank">CDN Uptime</a></li>
-                <li><a href="https://status.cdnjs.com" target="_blank">Status Page</a></li>
+                <li>
+                  <a href="https://status.cdnjs.com" target="_blank">
+                    Status Page <span class="status-color-dot"></span>
+                  </a>
+                </li>
                 <li><a href="https://twitter.com/cdnjsStatus" target="_blank">cdnjsStatus on Twitter</a></li>
               </ul>
             </div>
@@ -158,6 +162,16 @@ $('.post code').addClass('hljs');
 $('.post').show();
     </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollup/2.4.1/jquery.scrollUp.min.js" integrity="sha256-t2YrqZoTLq/Qt8zIw0BMiuRC2X5+a3O7PODU8RwoyYw=" crossorigin="anonymous"></script>
+
+  <script src="https://cdn.statuspage.io/se-v2.js"></script>
+  <script defer>
+    var sp = new StatusPage.page({page: '1fkb7yl9sw87'});
+    sp.status({
+      success: function(data) {
+        $('.status-color-dot').addClass(data.status.indicator);
+      }
+    });
+  </script>
 
 <script defer>hljs.initHighlightingOnLoad();</script>
 <div itemscope itemtype="https://schema.org/WebSite" style="display:none">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -163,6 +163,7 @@ $('.post').show();
     </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollup/2.4.1/jquery.scrollUp.min.js" integrity="sha256-t2YrqZoTLq/Qt8zIw0BMiuRC2X5+a3O7PODU8RwoyYw=" crossorigin="anonymous"></script>
 
+  <script src="https://1fkb7yl9sw87.statuspage.io/embed/script.js"></script>
   <script src="https://cdn.statuspage.io/se-v2.js"></script>
   <script defer>
     var sp = new StatusPage.page({page: '1fkb7yl9sw87'});


### PR DESCRIPTION
 - Implement a status indicator in the footer of all pages on site, making use of the Statuspage.io JS library (SRI doesn't appear to be supported?).
 - Added links to the [status page](https://status.cdnjs.com/) and [status twitter](https://twitter.com/cdnjsStatus) account in the navbar under the Network label (now a dropdown called "Network & Status").
 - Move uptime to be under the network/status dropdown.
 - Include status indicator next to status page link in navbar dropdown.