### PR TITLE
Add `package-lock.json` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build/Release
 node_modules
 
 cache/*
+package-lock.json


### PR DESCRIPTION
Resolves #257 by adding the `package-lock.json` file to `.gitignore`.