### PR TITLE
[Website] Update Support Us! links

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -79,6 +79,7 @@
               </a>
               <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="supportGroupDrop">
                 <li><a href="https://www.bountysource.com/teams/cdnjs" target="_blank">via Bountysource</a></li>
+                <li><a href="https://www.patreon.com/cdnjs" target="_blank">via Patreon</a></li>
                 <li><a href="https://liberapay.com/cdnjs/" target="_blank">via Liberapay</a></li>
                 <li><a href="https://tip4commit.com/github/cdnjs/cdnjs" target="_blank">via tip4commit</a></li>
                 <li><a href="https://twitter.com/cdnjs" target="_blank">Contact us!</a></li>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -78,6 +78,7 @@
                 Support us! <span class="caret"></span>
               </a>
               <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="supportGroupDrop">
+                <li><a href="https://opencollective.com/cdnjs" target="_blank">via Open Collective</a></li>
                 <li><a href="https://www.bountysource.com/teams/cdnjs" target="_blank">via Bountysource</a></li>
                 <li><a href="https://www.patreon.com/cdnjs" target="_blank">via Patreon</a></li>
                 <li><a href="https://liberapay.com/cdnjs/" target="_blank">via Liberapay</a></li>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -102,7 +102,11 @@
     <footer class="footer">
       <div class="container">
         <p class="text-muted">
-          Donate CDNJS $5 on <a href="https://www.bountysource.com/teams/cdnjs" target="_blank">Bountysource</a> or become a contributor on <a href="https://github.com/cdnjs/cdnjs" target="_blank"><i class="fa fa-github"></i> GitHub</a> to make the project better and better!
+          Donate $5 to CDNJS on <a href="https://www.bountysource.com/teams/cdnjs" target="_blank">Bountysource</a>,
+          via <a href="https://opencollective.com/cdnjs" target="_blank">Open Collective</a>, on
+          <a href="https://www.patreon.com/cdnjs" target="_blank">Patreon</a> or become a contributor on
+          <a href="https://github.com/cdnjs/cdnjs" target="_blank"><i class="fa fa-github"></i> GitHub</a> to make the
+          project better and better!
           <span class="pull-right">
             <a href="https://twitter.com/cdnjs" target="_blank"><i class="fa fa-twitter-square"></i> Twitter</a>
             &nbsp; <a href="https://cdnjs.discourse.group/" target="_blank"><i class="fa fa-comments"></i> Discourse</a>


### PR DESCRIPTION
This pull request intends to make the following changes to the website:
 - Add Patreon to the Support Us! dropdown as a monthly donation option
 - Add Open Collective to the Support Us! dropdown as another monthly donation option
 - Add Patreon & Open Collective to the donation message in the footer of the site
 - Fix wording of the donation footer, making it flow more easily

![image](https://user-images.githubusercontent.com/12371363/59163468-8d158b80-8af9-11e9-94d8-5f4866c55b55.png)