### PR TITLE
[Website] Migrate from FontAwesome 4.7.0 -> 5.8.2

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -245,10 +245,10 @@ function setFileURLs(new_provider) {
         var user = getSafeHighlightedValue(hit._highlightResult.github.user);
         var repo = getSafeHighlightedValue(hit._highlightResult.github.repo);
         githubDetails = '<ul class="list-inline">' +
-          '<li><i class="fa fa-github"></i> <a href="https://github.com/' + hit.github.user + '/' + hit.github.repo + '" target="_blank">' + user + '/' + repo + '</a></li>' +
-          '<li><i class="fa fa-eye"></i> ' + hit.github.subscribers_count + '</li>' +
-          '<li><i class="fa fa-star"></i> ' + hit.github.stargazers_count + '</li>' +
-          '<li><i class="fa fa-code-fork"></i> ' + hit.github.forks + '</li>' +
+          '<li><i class="fab fa-github"></i> <a href="https://github.com/' + hit.github.user + '/' + hit.github.repo + '" target="_blank">' + user + '/' + repo + '</a></li>' +
+          '<li><i class="fas fa-eye"></i> ' + hit.github.subscribers_count + '</li>' +
+          '<li><i class="fas fa-star"></i> ' + hit.github.stargazers_count + '</li>' +
+          '<li><i class="fas fa-code-branch"></i> ' + hit.github.forks + '</li>' +
         '</ul>';
       }
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/themes/orange/pace-theme-minimal.min.css" integrity="sha256-kb8pRNu1sIwQEWAO/Mqt1S5PZ5xiLd4nBMoSsqdxKPs=" crossorigin="anonymous" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js" integrity="sha256-EPrkNjGEmCWyazb3A/Epj+W7Qm2pB9vnfXw+X6LImPM=" crossorigin="anonymous" async></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/united/bootstrap.min.css" integrity="sha256-IYGI0ovdtvTnw19p8rG6jZjmlX+5x+4rw9uAhk+5OC4=" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css" integrity="sha256-UzFD2WYH2U1dQpKDjjZK72VtPeWP50NoJjd26rnAdUI=" crossorigin="anonymous" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/main.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css" />
@@ -105,11 +105,11 @@
           Donate $5 to CDNJS on <a href="https://www.bountysource.com/teams/cdnjs" target="_blank">Bountysource</a>,
           via <a href="https://opencollective.com/cdnjs" target="_blank">Open Collective</a>, on
           <a href="https://www.patreon.com/cdnjs" target="_blank">Patreon</a> or become a contributor on
-          <a href="https://github.com/cdnjs/cdnjs" target="_blank"><i class="fa fa-github"></i> GitHub</a> to make cdnjs
+          <a href="https://github.com/cdnjs/cdnjs" target="_blank"><i class="fab fa-github"></i> GitHub</a> to make cdnjs
           sustainable!
           <span class="pull-right">
-            <a href="https://twitter.com/cdnjs" target="_blank"><i class="fa fa-twitter-square"></i> Twitter</a>
-            &nbsp; <a href="https://cdnjs.discourse.group/" target="_blank"><i class="fa fa-comments"></i> Discourse</a>
+            <a href="https://twitter.com/cdnjs" target="_blank"><i class="fab fa-twitter-square"></i> Twitter</a>
+            &nbsp; <a href="https://cdnjs.discourse.group/" target="_blank"><i class="fab fa-discourse"></i> Discourse</a>
           </span>
         </p>
       </div>

--- a/templates/library.html
+++ b/templates/library.html
@@ -9,9 +9,9 @@
     <h1 style="margin-top: 00px;" id="libraryName">{{library.name}}</h1>
     {{#watch}}
     <ul class="list-inline">
-      <li><i class="fa fa-eye"></i><strong> {{watch}}</strong></li>
-      <li><i class="fa fa-star"></i><strong> {{star}}</strong></li>
-      <li><i class="fa fa-code-fork"></i><strong> {{fork}}</strong></li>
+      <li><i class="fas fa-eye"></i><strong> {{watch}}</strong></li>
+      <li><i class="fas fa-star"></i><strong> {{star}}</strong></li>
+      <li><i class="fas fa-code-branch"></i><strong> {{fork}}</strong></li>
     </ul>
     {{/watch}}
     <p><a href="{{library.homepage}}">{{library.homepage}}</a>
@@ -19,7 +19,7 @@
       <p>
         <li class="label" style="color:Black">Links/Tags:</li>
         <li class="label label-default label-highlight"><a href="https://github.com/cdnjs/cdnjs/commits/master/ajax/libs/{{library.name}}" title="Commit history of {{library.name}} on cdnjs">commits/history</a></li>&nbsp;
-        <li class="label label-default label-highlight"><a href="https://api.cdnjs.com/libraries/{{library.name}}" title="api url of {{library.name}} on cdnjs">cdnjs api</a>&nbsp;<a href="https://api.cdnjs.com/libraries/{{library.name}}?output=human" title="Human readable api output of {{library.name}}">&nbsp;<i class="fa fa-user"></i></a></li>&nbsp;
+        <li class="label label-default label-highlight"><a href="https://api.cdnjs.com/libraries/{{library.name}}" title="api url of {{library.name}} on cdnjs">cdnjs api</a>&nbsp;<a href="https://api.cdnjs.com/libraries/{{library.name}}?output=human" title="Human readable api output of {{library.name}}">&nbsp;<i class="fas fa-user"></i></a></li>&nbsp;
         <a href="{{library.autoupdate.url}}" title="{{library.name}} has auto-update config, this is the link to upstream, click to checkout lastest version on official page."><li class="label label-default label-highlight">{{library.autoupdate.string}}</li></a>
         {{#library.urls}}
         &nbsp;<li class="label label-default label-highlight"><a href="{{url}}" title="Link to {{library.name}}'s source code page.">repository</a></li>

--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -81,19 +81,19 @@ p > code.hljs {
           <a href="{{author.homepage}}" target="_blank">{{author.homepage}}</a><br />
 
           {{#author.twitter}}
-            <a href="https://twitter.com/{{author.twitter}}" target="_blank"><i class="fa fa-twitter"></i></a>
+            <a href="https://twitter.com/{{author.twitter}}" target="_blank"><i class="fab fa-twitter"></i></a>
           {{/author.twitter}}
           {{#author.github}}
-            <a href="https://github.com/{{author.github}}" target="_blank"><i class="fa fa-github"></i></a>
+            <a href="https://github.com/{{author.github}}" target="_blank"><i class="fab fa-github"></i></a>
           {{/author.github}}
           {{#author.medium}}
-            <a href="https://medium.com/@{{author.medium}}" target="_blank"><i class="fa fa-medium"></i></a>
+            <a href="https://medium.com/@{{author.medium}}" target="_blank"><i class="fab fa-medium"></i></a>
           {{/author.medium}}
           {{#author.facebook}}
-            <a href="https://facebook.com/{{author.facebook}}" target="_blank"><i class="fa fa-facebook"></i></a>
+            <a href="https://facebook.com/{{author.facebook}}" target="_blank"><i class="fab fa-facebook-f"></i></a>
           {{/author.facebook}}
           {{#author.reddit}}
-            <a href="https://reddit.com/user/{{author.reddit}}" target="_blank"><i class="fa fa-reddit"></i></a>
+            <a href="https://reddit.com/user/{{author.reddit}}" target="_blank"><i class="fab fa-reddit"></i></a>
           {{/author.reddit}}
           </p>
         </div>


### PR DESCRIPTION
This PR fixes #260
**Migrating the website from FontAwesome 4.7.0 to the newer 5.8.2**
 - Replace comments icon with correct Discourse icon in footer
 - Replace all other icons like for like