### PR TITLE
[Website] Add info points to homepage

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -183,3 +183,22 @@ p#date{
   font-weight: 500;
   font-style: normal;
 }
+
+.home-info {
+  color: #dd4814;
+  padding: 20px 0;
+}
+
+.home-info ul {
+  list-style: none;
+  font-size: 16px;
+  padding: 0;
+}
+
+.home-info ul li {
+  display: inline-block;
+}
+
+.home-info ul li:not(:first-child) i {
+  margin-left: 0.5em;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -329,10 +329,12 @@ function setFileURLs(new_provider) {
 
   function animateTop() {
     $('.container.home').animate({ marginTop: '0px' }, 200);
+    $('.row.home-info').hide(200);
   }
 
   function animateTopReverse() {
     $('.container.home').animate({ marginTop: '200px' }, 200);
+    $('.row.home-info').show(200);
   }
 
   var clearHash = _.once(function () {

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,4 +1,24 @@
 <div class="container">
+  <div class="row home-info">
+    <div class="col-md-12">
+      <p>The #1 free and open source CDN built to make life easier for developers.</p>
+      <ul>
+        <li><i class="fa fa-check-circle"></i>
+          <a href="https://github.com/cdnjs/cdnjs" target="_blank">Open Source</a></li>
+        <li><i class="fa fa-check-circle"></i> Free to Use</li>
+        <li><i class="fa fa-check-circle"></i> Supports
+          <a href="https://en.wikipedia.org/wiki/HTTPS" target="_blank">HTTPS</a> &amp;
+          <a href="https://en.wikipedia.org/wiki/HTTP/2" target="_blank">http/2.0</a></li>
+        <li><i class="fa fa-check-circle"></i>
+          <a href="https://www.w3.org/TR/SRI/" target="_blank">SRI implemented</a></li>
+        <li><i class="fa fa-check-circle"></i>
+          <a href="https://trends.builtwith.com/cdn/CDN-JS" target="_blank">Used by over 4 million sites</a></li>
+        <li><i class="fa fa-check-circle"></i>
+          <a href="https://w3techs.com/blog/entry/web_technologies_of_the_year_2018" target="_blank">
+            Top W3Techs CDN for 3 years</a></li>
+      </ul>
+    </div>
+  </div>
   <div class="row">
     <div class="col-md-12">
         <input id="search-box" placeholder="Search from {{libCount}} libraries with {{libVerCount}} different versions ..." type="text" class="form-control col-md-7 search" aria-controls="example">


### PR DESCRIPTION
This change was originally part of #263 
This pull request intends to make the following changes:
 - Add a set of info points to the homepage that acts as the key selling points for the service we provide.
 - The motive for this is to hopefully explain the service better to users who have reached the homepage for the first time as it currently does not.

| New | Old |
|------|-----|
| ![image](https://user-images.githubusercontent.com/12371363/60399377-7f34b280-9b5b-11e9-994d-1395ff77c08e.png) | ![image](https://user-images.githubusercontent.com/12371363/60399383-88258400-9b5b-11e9-80b7-034dad062de3.png) |