### PR TITLE
[Website] Fix copy button padding

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -66,6 +66,7 @@
 }
 .copy-button-group .copy-button {
     padding-left: 4px;
+    padding-right: 4px;
     font-size: 15px;
 }
 


### PR DESCRIPTION
Sorry about this small PR 😅but this really bothered me more than it should.
I did try to look for other small tweaks I could add but didn't find any.

Before:
![image](https://user-images.githubusercontent.com/11406433/66256186-aa96f100-e78b-11e9-8300-d94bfeb92f04.png)
![image](https://user-images.githubusercontent.com/11406433/66256190-b5518600-e78b-11e9-98a8-877ffed16b25.png)

After:
![image](https://user-images.githubusercontent.com/11406433/66256175-7b807f80-e78b-11e9-8563-70460f8c49ca.png)
![image](https://user-images.githubusercontent.com/11406433/66256185-96eb8a80-e78b-11e9-9a80-e1e61793b69e.png)