### PR TITLE
Switch to showing script tags in library listing to increase use of SRI

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -186,7 +186,7 @@ tr {
   font-size: 16px;
 }
 
-.library-url {
+.library-url, .script-tag {
   margin: 5px 0 5px;
 
   /* Selection helper */

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -253,6 +253,7 @@ function setFileURLs(new_provider) {
       }
 
       var description = getSafeHighlightedValue(hit._highlightResult.description);
+      var uri = cdn_provider_base_url[cdn_provider] + hit.originalName + '/' + hit.version + '/' + hit.filename;
       var row = '<tr id="' + hit.objectID + '" data-sri="' + hit.sri + '">' +
         '<td>' +
           '<a id="libLink" href="/libraries/' + hit.name + '">' +
@@ -267,9 +268,9 @@ function setFileURLs(new_provider) {
           '</ul>' +
           githubDetails +
         '</td>' +
-        '<td style="white-space: nowrap;">' +
+        '<td>' +
           '<div style="position: relative; padding: 8px;" data-lib-name="' + hit.name + '" class="library-column ' + hit.fileType + '-type">' +
-            '<p itemprop="downloadUrl" class="library-url" style="padding: 0; margin: 0">' + cdn_provider_base_url[cdn_provider] + hit.originalName + '/' + hit.version + '/' + hit.filename + '</p>' +
+            '<p itemprop="scriptTag" class="script-tag" style="padding: 0; margin: 0">&lt;script src="' + uri + '" integrity="' + hit.sri + '">&lt;/script></p>' +
           '</div>' +
         '</td>' +
       '</tr>';

--- a/templates/home.html
+++ b/templates/home.html
@@ -15,7 +15,7 @@
           <thead>
             <tr>
               <th>Library</th>
-              <th>Link</th>
+              <th>Script Tag</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
The goal of this change is to increase usage of SRI by showing the full script tag rather than just the URL by default.

![image](https://user-images.githubusercontent.com/55347/70299880-13085a00-1831-11ea-95ca-c36c6050804b.png)
