### PR TITLE
[API] Always use Algolia for /libraries

### DIFF
--- a/apiServer.js
+++ b/apiServer.js
@@ -108,10 +108,10 @@ app.get('/libraries', function (req, res) {
     browser.on('error', function (error) {
       reject(error);
     });
-    browser.on('end', function() {
+    browser.on('end', function () {
       resolve();
     });
-  }).then(function() {
+  }).then(function () {
     var json = {
       results: formatResults(fields, allhits),
       total: allhits.length
@@ -121,7 +121,7 @@ app.get('/libraries', function (req, res) {
     } else {
       res.jsonp(json);
     }
-  }).catch(function(error) {
+  }).catch(function (error) {
     res.status(500).send(error.message);
   });
 });

--- a/templates/api.html
+++ b/templates/api.html
@@ -40,17 +40,6 @@
         </p>
 
         <p>
-          The libraries API endpoint will return the maximum Algolia results by default (1000), but you can limit these
-          with the "hitsPerPage" query
-          <br /><br />
-          <code>https://api.cdnjs.com/libraries?search=[query]&amp;hitsPerPage=10</code>
-          <br /><br />
-          If you are using the "hitsPerPage" query, you can also use "page" to paginate (defaulting at 0)
-          <br /><br />
-          <code>https://api.cdnjs.com/libraries?search=[query]&amp;hitsPerPage=10&amp;age=2</code>
-        </p>
-
-        <p>
           API will return minified result by default, if you wanna have a human readable result, try
           <code>output=human</code>
           like so:

--- a/templates/api.html
+++ b/templates/api.html
@@ -40,6 +40,17 @@
         </p>
 
         <p>
+          The libraries API endpoint will return the maximum Algolia results by default (1000), but you can limit these
+          with the "hitsPerPage" query
+          <br /><br />
+          <code>https://api.cdnjs.com/libraries?search=[query]&amp;hitsPerPage=10</code>
+          <br /><br />
+          If you are using the "hitsPerPage" query, you can also use "page" to paginate (defaulting at 0)
+          <br /><br />
+          <code>https://api.cdnjs.com/libraries?search=[query]&amp;hitsPerPage=10&amp;age=2</code>
+        </p>
+
+        <p>
           API will return minified result by default, if you wanna have a human readable result, try
           <code>output=human</code>
           like so:
@@ -68,7 +79,7 @@ license
 repository
 autoupdate
 author
-assets
+assets (only available on /libraries/:library)
 </code></pre>
 
         <p>The API is served over Cloudflare with a hour expiry for requests.</p>


### PR DESCRIPTION
Currently /libraries on the API uses in-memory data if no search query is given, which is killing the API app. This changes the behaviour of /libraries to always use Algolia.