### PR TITLE
Show `.ts` files in js list

### DIFF
--- a/webServer/utils/fileType.js
+++ b/webServer/utils/fileType.js
@@ -1,6 +1,7 @@
 /* eslint-disable key-spacing */
 const typeMap = {
   'js':     'js',
+  'ts':     'js',
   'map':    'map',
 
   'css':    'css',


### PR DESCRIPTION
Currently cdnjs saves typescript files but they aren't listed in the cdnjs website. This PR will add them in the js list.

If needed it can be added as a separate list but I noticed that `scss` files are also listed in the css list.