### PR TITLE
Ignore invalid libraries when loading data in

### DIFF
--- a/webServer/utils/libraries.js
+++ b/webServer/utils/libraries.js
@@ -23,6 +23,8 @@ const all = () => {
   const librariesMap = {};
   let versions = 0;
   libraries.forEach(library => {
+    if (!library || !library.name || !library.assets) return;
+
     library.originalName = library.name;
     library.id = library.name;
 


### PR DESCRIPTION
In relation to https://github.com/cdnjs/cdnjs/issues/13986, the newly generated data contains some blank entires that are causing the site to continue to fall over, even after the data corruption issue was resolved.