### PR TITLE
Parse & re-stringify JSON SRI data

### DIFF
--- a/webServer/utils/libraries.js
+++ b/webServer/utils/libraries.js
@@ -266,7 +266,7 @@ const response = (req, res) => {
   // Attempt to get SRI data for the version
   let SRI;
   try {
-    SRI = fs.readFileSync('sri/' + libraryName + '/' + version + '.json');
+    SRI = JSON.parse(fs.readFileSync('sri/' + libraryName + '/' + version + '.json', 'utf8'));
   } catch (_) {
     SRI = {};
   }
@@ -301,7 +301,7 @@ const response = (req, res) => {
       data: {
         library: library,
         assets: libraryAssets,
-        SRI: SRI,
+        SRI: JSON.stringify(SRI),
         licenses: libraryLicenses,
         selectedAssets: librarySelectedAssets[0],
         tutorials: tutorialPackages,


### PR DESCRIPTION
As noted in some reports overnight, the site briefly had some bad SRI data that was then cached on certain pages. This PR does NOT fix this.

However, this did raise an issue with the default value used for SRI if it fails to load data. Currently, the logic just reads in the raw JSON file for SRI data and spits it back out. If not SRI data is found, it will attempt to spit out an empty object without converting it to JSON first, resulting in the `[object Object]` reported by some folks.

This changes the logic to parse the read in SRI JSON data first, within the existing try/catch. This is actually better as we'll make sure that the JSON is valid before using it. If reading in the JSON fails, the same fallback empty object will be used. However, as we're now parsing the JSON data, we then call stringify on the data (or empty object) before sending it to the frontend, which should mean in the event things went wrong we'd simply see an empty object and not `[object Object]`.