### PR TITLE
Remove HPKP headers

### DIFF
--- a/apiServer.js
+++ b/apiServer.js
@@ -71,11 +71,6 @@ packages = null;
 var algoliaIndex = algoliasearch('2QWLVLXZB6', 'e16bd99a5c7a8fccae13ad40762eec3c').initIndex('libraries');
 
 if (!localMode && (typeof global.gc !== 'undefined')) {
-  app.use(function (req, res, next) {
-    res.setHeader('Public-Key-Pins', 'pin-sha256="EULHwYvGhknyznoBvyvgbidiBH3JX3eFHHlIO3YK8Ek=";pin-sha256="x9SZw6TwIqfmvrLZ/kz1o0Ossjmn728BnBKpUFqGNVM=";max-age=3456000;report-uri="https://cdnjs.report-uri.io/r/default/hpkp/enforce"');
-    next();
-  });
-
   global.gc();
 }
 

--- a/webServer/app.js
+++ b/webServer/app.js
@@ -20,7 +20,7 @@ const args = process.argv.slice(2);
 // Local mode state
 let localMode = false;
 if (process.env.LOCAL === 'true' || (args.length > 0 && (args[0] === '--local' || args[2] === '--local'))) {
-  console.log('local mode: on, gc(), CSP and Public-Key-Pins headers disabled!');
+  console.log('local mode: on, gc() and CSP headers disabled!');
   localMode = true;
 } else {
   console.log('local mode: off');
@@ -47,7 +47,6 @@ module.exports = () => {
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-XSS-Protection', '1; mode=block');
     if (!localMode) {
-      res.setHeader('Public-Key-Pins', 'pin-sha256="EULHwYvGhknyznoBvyvgbidiBH3JX3eFHHlIO3YK8Ek=";pin-sha256="x9SZw6TwIqfmvrLZ/kz1o0Ossjmn728BnBKpUFqGNVM=";max-age=3456000;report-uri="https://cdnjs.report-uri.io/r/default/hpkp/enforce');
       res.setHeader('Content-Security-Policy', "upgrade-insecure-requests; default-src 'unsafe-eval' 'self' *.carbonads.com *.getclicky.com fonts.gstatic.com www.google-analytics.com fonts.googleapis.com cdnjs.cloudflare.com 'unsafe-inline' https: data: ;report-uri https://cdnjs.report-uri.io/r/default/hpkp/enforce");
     }
     next();


### PR DESCRIPTION
HPKP isn't supported by any mainstream browsers these days[1][2], and
the pins seems to be out-of-date.

[1] https://www.chromestatus.com/feature/5903385005916160
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1412438